### PR TITLE
Add basic Bitwarden-like UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,5 @@
 #root {
-  max-width: 1280px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,18 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import Login from './components/Login'
+import Vault from './components/Vault'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [loggedIn, setLoggedIn] = useState(false)
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      {loggedIn ? (
+        <Vault onLogout={() => setLoggedIn(false)} />
+      ) : (
+        <Login onLogin={() => setLoggedIn(true)} />
+      )}
     </>
   )
 }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { Box, TextField, Button } from '@mui/material'
+
+interface LoginProps {
+  onLogin: () => void
+}
+
+export default function Login({ onLogin }: LoginProps) {
+  const stored = localStorage.getItem('masterPassword')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = () => {
+    if (stored) {
+      if (password === stored) {
+        onLogin()
+      } else {
+        setError('Incorrect password')
+      }
+    } else {
+      localStorage.setItem('masterPassword', password)
+      onLogin()
+    }
+  }
+
+  return (
+    <Box maxWidth={400} mx="auto" mt={4} display="flex" flexDirection="column" gap={2}>
+      <TextField
+        type="password"
+        label={stored ? 'Master Password' : 'Create Master Password'}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      {error && <span style={{ color: 'red' }}>{error}</span>}
+      <Button variant="contained" onClick={handleSubmit} disabled={!password}>
+        {stored ? 'Unlock' : 'Create'}
+      </Button>
+    </Box>
+  )
+}
+

--- a/src/components/Vault.tsx
+++ b/src/components/Vault.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import { Box, Button, TextField, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
+
+interface VaultItem {
+  id: number
+  name: string
+  username: string
+  password: string
+}
+
+interface VaultProps {
+  onLogout: () => void
+}
+
+export default function Vault({ onLogout }: VaultProps) {
+  const [items, setItems] = useState<VaultItem[]>(() => {
+    const saved = localStorage.getItem('vaultItems')
+    return saved ? JSON.parse(saved) : []
+  })
+  const [name, setName] = useState('')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const saveItems = (newItems: VaultItem[]) => {
+    setItems(newItems)
+    localStorage.setItem('vaultItems', JSON.stringify(newItems))
+  }
+
+  const handleAdd = () => {
+    const newItem: VaultItem = { id: Date.now(), name, username, password }
+    const newItems = [...items, newItem]
+    saveItems(newItems)
+    setName('')
+    setUsername('')
+    setPassword('')
+  }
+
+  const handleCopy = (value: string) => {
+    navigator.clipboard.writeText(value)
+  }
+
+  return (
+    <Box p={2}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <h2>Vault</h2>
+        <Button onClick={onLogout}>Logout</Button>
+      </Box>
+
+      <Box display="flex" gap={2} mb={2}>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <TextField label="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <Button variant="contained" onClick={handleAdd} disabled={!name || !username || !password}>Add</Button>
+      </Box>
+
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Username</TableCell>
+            <TableCell>Password</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {items.map(item => (
+            <TableRow key={item.id}>
+              <TableCell>{item.name}</TableCell>
+              <TableCell>
+                {item.username}
+                <Button size="small" onClick={() => handleCopy(item.username)}>Copy</Button>
+              </TableCell>
+              <TableCell>
+                ****
+                <Button size="small" onClick={() => handleCopy(item.password)}>Copy</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add login screen with master password storage
- implement simple vault for adding and copying credentials
- clean up default Vite styling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c63529734832b986f4e880561b20d