### PR TITLE
Add basic Material UI vault layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
         "@tanstack/react-query": "^5.85.0",
         "react": "^19.1.1",
@@ -1944,6 +1945,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.1.tgz",
+      "integrity": "sha512-upzCtG6awpL6noEZlJ5Z01khZ9VnLNLaj7tb6iPbN6G97eYfUTs8e9OyPKy3rEms3VQWmVBfri7jzeaRxdFIzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.1",
     "@mui/material": "^7.3.1",
     "@tanstack/react-query": "^5.85.0",
     "react": "^19.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,64 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  Typography,
+  Drawer,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Box,
+} from '@mui/material'
+import { Add as AddIcon, Menu as MenuIcon } from '@mui/icons-material'
+import ItemDetailDialog from './ItemDetailDialog'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton edge="start" color="inherit" onClick={() => setDrawerOpen(true)}>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            My Password Vault
+          </Typography>
+          <IconButton color="inherit" onClick={() => setDialogOpen(true)}>
+            <AddIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+        <List>
+          <ListItem button>
+            <ListItemText primary="All Items" />
+          </ListItem>
+          <ListItem button>
+            <ListItemText primary="Logins" />
+          </ListItem>
+          <ListItem button>
+            <ListItemText primary="Secure Notes" />
+          </ListItem>
+        </List>
+      </Drawer>
+
+      <Box sx={{ p: 2 }}>
+        <TextField label="Search" variant="outlined" fullWidth sx={{ mb: 2 }} />
+        <Typography variant="body2" color="text.secondary">
+          Your items will appear here.
+        </Typography>
+      </Box>
+
+      <ItemDetailDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
     </>
   )
 }
 
 export default App
+

--- a/src/ItemDetailDialog.tsx
+++ b/src/ItemDetailDialog.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  IconButton,
+  InputAdornment,
+} from '@mui/material'
+import {
+  Visibility,
+  VisibilityOff,
+  ContentCopy,
+} from '@mui/icons-material'
+
+interface ItemDetailDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export default function ItemDetailDialog({ open, onClose }: ItemDetailDialogProps) {
+  const [showPass, setShowPass] = useState(false)
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Login Details</DialogTitle>
+      <DialogContent>
+        <TextField margin="dense" label="Username" fullWidth />
+        <TextField
+          margin="dense"
+          label="Password"
+          type={showPass ? 'text' : 'password'}
+          fullWidth
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={() => setShowPass(!showPass)}>
+                  {showPass ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+                <IconButton>
+                  <ContentCopy />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained">Save</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace default template with vault layout using Material UI AppBar, drawer, and search field
- add dialog component for viewing or editing item details
- include @mui/icons-material dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c69df4e38832b966371ea40757b3a