### PR TITLE
Upravit layout hlavní stránky

### DIFF
--- a/src/components/PasswordDetail.tsx
+++ b/src/components/PasswordDetail.tsx
@@ -9,7 +9,8 @@ export default function PasswordDetail() {
       square
       elevation={0}
       sx={{
-        width: 320,
+        width: { xs: 320, md: '35%' },
+        minWidth: 320,
         borderLeft: 1,
         borderColor: 'divider',
         height: '100vh',

--- a/src/components/PasswordGrid.tsx
+++ b/src/components/PasswordGrid.tsx
@@ -11,9 +11,9 @@ const passwords = Array.from({ length: 9 }, (_, i) => ({
 
 export default function PasswordGrid() {
   return (
-    <Grid container spacing={2} p={3} sx={{ flexGrow: 1, bgcolor: 'grey.50', overflow: 'auto' }}>
+    <Grid container spacing={2} p={3} columns={3} sx={{ flexGrow: 1, bgcolor: 'grey.50', overflow: 'auto' }}>
       {passwords.map((p) => (
-        <Grid item xs={12} sm={4} key={p.id}>
+        <Grid item xs={1} key={p.id}>
           <Card variant="outlined">
             <CardActionArea>
               <CardContent>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,17 +2,14 @@ import AppBar from '@mui/material/AppBar'
 import Toolbar from '@mui/material/Toolbar'
 import TextField from '@mui/material/TextField'
 import Button from '@mui/material/Button'
-import Stack from '@mui/material/Stack'
 
 export default function SearchBar() {
   return (
     <AppBar position="static" color="transparent" elevation={0} sx={{ borderBottom: 1, borderColor: 'divider' }}>
-      <Toolbar sx={{ justifyContent: 'center' }}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <TextField size="small" placeholder="Vyhledat" />
-          <Button variant="outlined">Generátor</Button>
-          <Button variant="contained">Nová položka</Button>
-        </Stack>
+      <Toolbar sx={{ gap: 2 }}>
+        <TextField size="small" placeholder="Vyhledat" sx={{ flexGrow: 1 }} />
+        <Button variant="outlined">Generátor</Button>
+        <Button variant="contained">Nová položka</Button>
       </Toolbar>
     </AppBar>
   )


### PR DESCRIPTION
## Summary
- Vyhledávací pole zabírá většinu horní lišty a tlačítka jsou vpravo
- Panel s detailem má minimálně třetinu šířky okna
- Mřížka hesel je omezena na tři sloupce

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c7f1d7bcc832bbc5af79e24241dea