### PR TITLE
feat: use domain types on main page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,34 @@ import Sidebar from './components/Sidebar'
 import SearchBar from './components/SearchBar'
 import PasswordGrid from './components/PasswordGrid'
 import PasswordDetail from './components/PasswordDetail'
+import { Password } from './types'
+
+const passwords: Password[] = [
+  {
+    Id: 1,
+    FolderId: 1,
+    Name: 'Heslo 1',
+    Description: 'Popis 1',
+    PasswordId: 1,
+    UserName: 'user1',
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+    UpdatedBy: 1,
+    UpdatedAt: new Date(),
+  },
+  {
+    Id: 2,
+    FolderId: 1,
+    Name: 'Heslo 2',
+    Description: 'Popis 2',
+    PasswordId: 2,
+    UserName: 'user2',
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+    UpdatedBy: 1,
+    UpdatedAt: new Date(),
+  },
+]
 
 export default function App() {
   return (
@@ -10,7 +38,7 @@ export default function App() {
       <Sidebar />
       <Box flexGrow={1} display="flex" flexDirection="column">
         <SearchBar />
-        <PasswordGrid />
+        <PasswordGrid passwords={passwords} />
       </Box>
       <PasswordDetail />
     </Box>

--- a/src/components/PasswordGrid.tsx
+++ b/src/components/PasswordGrid.tsx
@@ -3,21 +3,21 @@ import Card from '@mui/material/Card'
 import CardActionArea from '@mui/material/CardActionArea'
 import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
+import { Password } from '../types'
 
-const passwords = Array.from({ length: 9 }, (_, i) => ({
-  id: i + 1,
-  name: `Heslo ${i + 1}`,
-}))
+interface PasswordGridProps {
+  passwords: Password[]
+}
 
-export default function PasswordGrid() {
+export default function PasswordGrid({ passwords }: PasswordGridProps) {
   return (
     <Grid container spacing={2} p={3} columns={3} sx={{ flexGrow: 1, bgcolor: 'grey.50', overflow: 'auto' }}>
       {passwords.map((p) => (
-        <Grid item xs={1} key={p.id}>
+        <Grid item xs={1} key={p.Id}>
           <Card variant="outlined">
             <CardActionArea>
               <CardContent>
-                <Typography variant="body2">{p.name}</Typography>
+                <Typography variant="body2">{p.Name}</Typography>
               </CardContent>
             </CardActionArea>
           </Card>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,42 @@
+export interface User {
+  id: number
+  username: string
+  firstName: string
+  lastName: string
+}
+
+export interface UserFolderRoles {
+  UserId: number
+  FolderId: number
+  RoleId: number
+  CreatedBy: number
+  CreatedAt: Date
+}
+
+export interface Role {
+  Id: number
+  Name: string
+  Code: string
+}
+
+export interface Folder {
+  Id: number
+  Name: string
+  CreatedBy: number
+  CreatedAt: Date
+  UpdatedBy: number
+  UpdatedAt: Date
+}
+
+export interface Password {
+  Id: number
+  FolderId: number
+  Name: string
+  Description: string
+  PasswordId: number
+  UserName: string
+  CreatedBy: number
+  CreatedAt: Date
+  UpdatedBy: number
+  UpdatedAt: Date
+}


### PR DESCRIPTION
## Summary
- add sample `Password[]` to main page and pass to grid
- update password grid to render typed passwords

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8d27a3dc832ba6852c8017b73bf9