### PR TITLE
refactor: replace GridLegacy with Grid

### DIFF
--- a/src/components/PasswordGrid.tsx
+++ b/src/components/PasswordGrid.tsx
@@ -11,9 +11,9 @@ interface PasswordGridProps {
 
 export default function PasswordGrid({ passwords }: PasswordGridProps) {
   return (
-    <Grid container spacing={2} p={3} columns={3} sx={{ flexGrow: 1, bgcolor: 'grey.50', overflow: 'auto' }}>
+    <Grid container spacing={2} p={3} columns={{ xs: 3 }} sx={{ flexGrow: 1, bgcolor: 'grey.50', overflow: 'auto' }}>
       {passwords.map((p) => (
-        <Grid item xs={1} key={p.Id}>
+        <Grid size={1} key={p.Id}>
           <Card variant="outlined">
             <CardActionArea>
               <CardContent>


### PR DESCRIPTION
## Summary
- refactor PasswordGrid to use MUI Grid instead of GridLegacy
- adopt `size` prop for items and remove legacy `item` syntax

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c94dbc51c832bb084b1a935821342