### PR TITLE
feat: add mock data for app types

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,0 +1,74 @@
+import type { User, Role, Folder, Password, UserFolderRoles } from '@types'
+
+export const mockUsers: User[] = [
+  { id: 1, username: 'admin', firstName: 'Admin', lastName: 'User' },
+  { id: 2, username: 'jdoe', firstName: 'John', lastName: 'Doe' },
+]
+
+export const mockRoles: Role[] = [
+  { Id: 1, Name: 'Administrator', Code: 'ADMIN' },
+  { Id: 2, Name: 'User', Code: 'USER' },
+]
+
+export const mockFolders: Folder[] = [
+  {
+    Id: 1,
+    Name: 'Default',
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+    UpdatedBy: 1,
+    UpdatedAt: new Date(),
+  },
+  {
+    Id: 2,
+    Name: 'Shared',
+    CreatedBy: 2,
+    CreatedAt: new Date(),
+    UpdatedBy: 2,
+    UpdatedAt: new Date(),
+  },
+]
+
+export const mockPasswords: Password[] = [
+  {
+    Id: 1,
+    FolderId: 1,
+    Name: 'Email',
+    Description: 'Primary email account',
+    PasswordId: 1,
+    UserName: 'user1',
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+    UpdatedBy: 1,
+    UpdatedAt: new Date(),
+  },
+  {
+    Id: 2,
+    FolderId: 1,
+    Name: 'Bank',
+    Description: 'Online banking',
+    PasswordId: 2,
+    UserName: 'user2',
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+    UpdatedBy: 1,
+    UpdatedAt: new Date(),
+  },
+]
+
+export const mockUserFolderRoles: UserFolderRoles[] = [
+  {
+    UserId: 1,
+    FolderId: 1,
+    RoleId: 1,
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+  },
+  {
+    UserId: 2,
+    FolderId: 1,
+    RoleId: 2,
+    CreatedBy: 1,
+    CreatedAt: new Date(),
+  },
+]

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,34 +3,7 @@ import Sidebar from '../components/Sidebar'
 import SearchBar from '../components/SearchBar'
 import PasswordGrid from '../components/PasswordGrid'
 import PasswordDetail from '../components/PasswordDetail'
-import type { Password } from '@types'
-
-const passwords: Password[] = [
-  {
-    Id: 1,
-    FolderId: 1,
-    Name: 'Heslo 1',
-    Description: 'Popis 1',
-    PasswordId: 1,
-    UserName: 'user1',
-    CreatedBy: 1,
-    CreatedAt: new Date(),
-    UpdatedBy: 1,
-    UpdatedAt: new Date(),
-  },
-  {
-    Id: 2,
-    FolderId: 1,
-    Name: 'Heslo 2',
-    Description: 'Popis 2',
-    PasswordId: 2,
-    UserName: 'user2',
-    CreatedBy: 1,
-    CreatedAt: new Date(),
-    UpdatedBy: 1,
-    UpdatedAt: new Date(),
-  },
-]
+import { mockPasswords } from '@mocks'
 
 export default function HomePage() {
   return (
@@ -38,7 +11,7 @@ export default function HomePage() {
       <Sidebar />
       <Box flexGrow={1} display="flex" flexDirection="column">
         <SearchBar />
-        <PasswordGrid passwords={passwords} />
+        <PasswordGrid passwords={mockPasswords} />
       </Box>
       <PasswordDetail />
     </Box>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
-      "@types": ["./src/types.ts"]
+      "@types": ["./src/types.ts"],
+      "@mocks": ["./src/mocks.ts"]
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@types': path.resolve(__dirname, './src/types.ts'),
+      '@mocks': path.resolve(__dirname, './src/mocks.ts'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add mock data for users, roles, folders, passwords and user folder roles
- expose mock passwords via @mocks alias in HomePage
- wire @mocks path alias in tsconfig and Vite config

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d96de45dc832b87d11e6e42c6a8e8