### PR TITLE
feat: simplify UI for minimalist design

### DIFF
--- a/src/components/PasswordGrid.tsx
+++ b/src/components/PasswordGrid.tsx
@@ -1,10 +1,8 @@
 import Paper from '@mui/material/Paper'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
-import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import IconButton from '@mui/material/IconButton'
-import LockIcon from '@mui/icons-material/Lock'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import type { Password } from '@types'
 
@@ -23,16 +21,12 @@ export default function PasswordGrid({ passwords }: PasswordGridProps) {
         {passwords.map((p) => (
           <ListItemButton
             key={p.Id}
-            divider
             sx={{
               py: 1.5,
               borderRadius: 1,
-              '&:hover': { bgcolor: 'grey.100' },
+              '&:hover': { bgcolor: 'action.hover' },
             }}
           >
-            <ListItemIcon sx={{ minWidth: 40 }}>
-              <LockIcon color="action" />
-            </ListItemIcon>
             <ListItemText
               primary={p.Name}
               secondary={p.UserName}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -14,13 +14,11 @@ export default function SearchBar() {
         position="static"
         color="default"
         elevation={0}
-        sx={{ bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}
+        sx={{ bgcolor: 'background.paper' }}
       >
         <Toolbar sx={{ gap: 2 }}>
           <TextField size="small" placeholder="Vyhledat" sx={{ flexGrow: 1 }} />
-          <Button variant="outlined" onClick={() => setOpen(true)}>
-            Generátor
-          </Button>
+          <Button onClick={() => setOpen(true)}>Generátor</Button>
           <Button variant="contained">Nová položka</Button>
         </Toolbar>
       </AppBar>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,6 @@ import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
-import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 import LockIcon from '@mui/icons-material/Lock'
 import FolderIcon from '@mui/icons-material/Folder'
@@ -23,13 +22,11 @@ export default function Sidebar({ folders }: SidebarProps) {
       sx={{
         width: 260,
         bgcolor: 'background.default',
-        borderRight: 1,
-        borderColor: 'divider',
         height: '100vh',
         p: 3,
         display: 'flex',
         flexDirection: 'column',
-        gap: 2,
+        gap: 3,
         flexShrink: 0,
       }}
     >
@@ -37,13 +34,14 @@ export default function Sidebar({ folders }: SidebarProps) {
         <LockIcon color="primary" />
         <Typography variant="h6">Klíčenka</Typography>
       </Stack>
-      <Divider />
-      <Typography variant="overline">Složky</Typography>
+      <Typography variant="overline" sx={{ mt: 1 }}>
+        Složky
+      </Typography>
       <List dense>
         {folders.map((folder) => (
           <ListItemButton
             key={folder.Id}
-            sx={{ pl: 1, borderRadius: 1, '&:hover': { bgcolor: 'grey.200' } }}
+            sx={{ pl: 1, borderRadius: 1, '&:hover': { bgcolor: 'action.hover' } }}
           >
             <ListItemIcon sx={{ minWidth: 32 }}>
               <FolderIcon fontSize="small" />
@@ -52,13 +50,14 @@ export default function Sidebar({ folders }: SidebarProps) {
           </ListItemButton>
         ))}
       </List>
-      <Divider />
-      <Typography variant="overline">Štítky</Typography>
+      <Typography variant="overline" sx={{ mt: 2 }}>
+        Štítky
+      </Typography>
       <List dense>
         {tags.map((tag) => (
           <ListItemButton
             key={tag}
-            sx={{ pl: 1, borderRadius: 1, '&:hover': { bgcolor: 'grey.200' } }}
+            sx={{ pl: 1, borderRadius: 1, '&:hover': { bgcolor: 'action.hover' } }}
           >
             <ListItemIcon sx={{ minWidth: 32 }}>
               <LabelIcon fontSize="small" />

--- a/src/index.css
+++ b/src/index.css
@@ -6,5 +6,8 @@ body,
 
 body {
   margin: 0;
+  font-family: system-ui, sans-serif;
+  background-color: #fff;
+  color: #111;
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,15 +7,18 @@ export const theme = createTheme({
       main: '#2563EB',
     },
     background: {
-      default: '#F7F8FA',
+      default: '#FFFFFF',
       paper: '#FFFFFF',
     },
     text: {
-      primary: '#1D2125',
-      secondary: '#44546F',
+      primary: '#111111',
+      secondary: '#555555',
     },
   },
   shape: {
-    borderRadius: 8,
+    borderRadius: 4,
+  },
+  typography: {
+    fontFamily: 'system-ui, sans-serif',
   },
 })


### PR DESCRIPTION
## Summary
- use neutral colors, white backgrounds and system font for a cleaner theme
- streamline sidebar, search bar and password grid for minimal UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689daa2e5d04832bb9a93c552c6f3e36