### PR TITLE
feat: add vault mock data and store

### DIFF
--- a/src/app/store/vault.ts
+++ b/src/app/store/vault.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import type { VaultItem } from '../../features/vault/data/mock'
+import { mockVaultItems } from '../../features/vault/data/mock'
+
+interface VaultState {
+  items: VaultItem[]
+  filters: {
+    text: string
+    tags: string[]
+    folder?: string
+  }
+  selectedId?: string
+  setItems: (items: VaultItem[]) => void
+  setFilterText: (text: string) => void
+  toggleTag: (tag: string) => void
+  setFolder: (folder?: string) => void
+  selectItem: (id?: string) => void
+  updateItemPartial: (id: string, partial: Partial<VaultItem>) => void
+  clearFilters: () => void
+}
+
+export const useVaultStore = create<VaultState>((set) => ({
+  items: mockVaultItems,
+  filters: {
+    text: '',
+    tags: [],
+    folder: undefined,
+  },
+  selectedId: undefined,
+  setItems: (items) => set({ items }),
+  setFilterText: (text) =>
+    set((state) => ({ filters: { ...state.filters, text } })),
+  toggleTag: (tag) =>
+    set((state) => {
+      const exists = state.filters.tags.includes(tag)
+      const tags = exists
+        ? state.filters.tags.filter((t) => t !== tag)
+        : [...state.filters.tags, tag]
+      return { filters: { ...state.filters, tags } }
+    }),
+  setFolder: (folder) =>
+    set((state) => ({ filters: { ...state.filters, folder } })),
+  selectItem: (id) => set({ selectedId: id }),
+  updateItemPartial: (id, partial) =>
+    set((state) => ({
+      items: state.items.map((item) =>
+        item.id === id ? { ...item, ...partial } : item
+      ),
+    })),
+  clearFilters: () =>
+    set({ filters: { text: '', tags: [], folder: undefined } }),
+}))

--- a/src/features/vault/data/mock.ts
+++ b/src/features/vault/data/mock.ts
@@ -1,0 +1,43 @@
+export interface VaultItem {
+  id: string
+  name: string
+  username: string
+  password: string
+  tags: string[]
+  folder?: string
+}
+
+export const mockVaultItems: VaultItem[] = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    username: 'octocat',
+    password: 'secret',
+    tags: ['development', 'code'],
+    folder: 'Work',
+  },
+  {
+    id: 'banking',
+    name: 'Bankovnictví',
+    username: 'jdoe',
+    password: 'bankpass',
+    tags: ['finance'],
+    folder: 'Personal',
+  },
+  {
+    id: 'server-prod',
+    name: 'Server – prod',
+    username: 'root',
+    password: 'prodpass',
+    tags: ['server', 'prod'],
+    folder: 'Infrastructure',
+  },
+  {
+    id: 'reddit',
+    name: 'Reddit',
+    username: 'redditUser',
+    password: 'redditpass',
+    tags: ['social'],
+    folder: 'Personal',
+  },
+]


### PR DESCRIPTION
## Summary
- add mock vault items for GitHub, Bankovnictví, Server – prod and Reddit
- create Zustand vault store with filtering, selection and item updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dcbd16820832bb01f277c1b082e8b